### PR TITLE
Fixed "Download the source code" url location

### DIFF
--- a/OmniMIDIConfigurator/OmniMIDIConfigurator/Forms/Mandatory/MainWindow.cs
+++ b/OmniMIDIConfigurator/OmniMIDIConfigurator/Forms/Mandatory/MainWindow.cs
@@ -1520,7 +1520,7 @@ namespace OmniMIDIConfigurator
         private void downloadTheSourceCodeToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Program.DebugToConsole(false, "Opening OmniMIDI's GitHub page.", null);
-            Process.Start("https://github.com/KaleidonKep99/Keppy-s-MIDI-Driver");
+            Process.Start("https://github.com/KeppySoftware/OmniMIDI");
         }
 
         private void donateToSupportUsToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
from https://github.com/KaleidonKep99/Keppy-s-MIDI-Driver
to https://github.com/KeppySoftware/OmniMIDI